### PR TITLE
feat: OpenAPI scaffolding, visibility gate, /api/docs

### DIFF
--- a/api/docs.ts
+++ b/api/docs.ts
@@ -1,0 +1,20 @@
+export default function handler(_req: any, res: any) {
+  const html = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Wayfinder API Docs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger"></div>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      window.ui = SwaggerUIBundle({ url: '/api/openapi', dom_id: '#swagger' });
+    </script>
+  </body>
+</html>`;
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.send(html);
+}

--- a/api/openapi.ts
+++ b/api/openapi.ts
@@ -1,0 +1,9 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export default async function handler(req: any, res: any) {
+  const file = path.join(process.cwd(), 'openapi.json');
+  if (!fs.existsSync(file)) return res.status(404).json({ error: 'openapi.json not found' });
+  res.setHeader('Content-Type', 'application/json');
+  res.send(fs.readFileSync(file, 'utf8'));
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name init"
+    "openapi:build": "ts-node scripts/build-openapi.ts",
+"openapi:lint": "redocly lint openapi.json",
+"openapi:check": "node scripts/check-visibility.js",
+"openapi:types": "openapi-typescript openapi.json -o src/types/openapi.d.ts",
+"prebuild": "npm run openapi:build && npm run openapi:lint && npm run openapi:check && npm run openapi:types"
+
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "express": "^4.19.2",
     "firebase-admin": "^12.1.1",
     "helmet": "^7.1.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+"@asteasolutions/zod-to-openapi": "^7.1.0"
+
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
@@ -26,6 +28,9 @@
     "@types/node": "^20.14.2",
     "prisma": "^5.22.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.5"
+    "ts-node": "^10.9.2",
+"typescript": "^5.5.4",
+"@redocly/cli": "^1.16.1",
+"openapi-typescript": "^7.4.2"
   }
 }

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { OpenAPIRegistry, OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
+import { openapiBase } from './openapi.base';
+
+// ⬇️ Import register* functions from your controllers as you annotate them
+// Example (you'll create this next):
+import { registerJourneySchemas } from '../src/controllers/journeys.controller';
+
+const registry = new OpenAPIRegistry();
+registerJourneySchemas(registry); // add more as you go
+
+const generator = new OpenApiGeneratorV3(registry.definitions);
+const doc = generator.generateDocument(openapiBase as any);
+
+const out = path.join(process.cwd(), 'openapi.json');
+fs.writeFileSync(out, JSON.stringify(doc, null, 2));
+console.log('Wrote', out);

--- a/scripts/check-visibility.js
+++ b/scripts/check-visibility.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const doc = JSON.parse(fs.readFileSync('openapi.json','utf8'));
+
+const must = ['x-visibility','x-owner','x-sla'];
+const missing = [];
+
+for (const [p, item] of Object.entries(doc.paths || {})) {
+  for (const m of Object.keys(item)) {
+    const op = item[m];
+    if (!op || typeof op !== 'object') continue;
+    must.forEach(k => { if (!op[k]) missing.push(`${m.toUpperCase()} ${p} (${k})`); });
+  }
+}
+
+if (missing.length) {
+  console.error('❌ Missing required extensions on operations:\n' + missing.map(x=>' - '+x).join('\n'));
+  process.exit(1);
+}
+console.log('✅ All operations include x-visibility, x-owner, x-sla');

--- a/scripts/openapi.base.ts
+++ b/scripts/openapi.base.ts
@@ -1,0 +1,15 @@
+export const openapiBase = {
+  openapi: '3.0.3',
+  info: {
+    title: 'Wayfinder API',
+    version: '1.0.0',
+    description: 'Generated from controller annotations + Zod schemas',
+  },
+  servers: [{ url: '/api' }],
+  components: {
+    securitySchemes: {
+      bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' }
+    }
+  },
+  'x-required-extensions': ['x-visibility', 'x-owner', 'x-sla']
+};

--- a/src/controllers/journeys.controller.ts
+++ b/src/controllers/journeys.controller.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { extendZodWithOpenApi, OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+extendZodWithOpenApi(z);
+
+const Journey = z.object({
+  id: z.string().uuid().openapi({ example: 'b5f2f6d4-5a38-4b7e-9b8a-2d8c1e2c0b24' }),
+  name: z.string().min(1),
+  status: z.enum(['draft','active','archived']),
+}).openapi('Journey');
+
+const CreateJourneyBody = z.object({
+  name: z.string().min(1),
+}).openapi('CreateJourneyBody');
+
+export function registerJourneySchemas(registry: OpenAPIRegistry) {
+  registry.register('Journey', Journey);
+  registry.register('CreateJourneyBody', CreateJourneyBody);
+}
+
+/**
+ * @openapi
+ * /journeys:
+ *   post:
+ *     summary: Create a journey
+ *     description: Creates a new journey and returns it.
+ *     operationId: createJourney
+ *     tags: [Journeys]
+ *     security:
+ *       - bearerAuth: []
+ *     x-visibility: public
+ *     x-owner: wayfinder-core
+ *     x-sla: standard
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateJourneyBody'
+ *     responses:
+ *       '201':
+ *         description: Journey created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Journey'
+ *       '400': { description: Validation error }
+ *       '401': { description: Unauthorized }
+ */
+export async function createJourney(_req: any, res: any) {
+  // stub impl for now
+  return res.status(201).json({ id: 'stub-id', name: 'Example', status: 'draft' });
+}


### PR DESCRIPTION
Adds OpenAPI scaffolding, visibility enforcement, and public docs endpoint

What’s new
OpenAPI generation using Zod + zod-to-openapi

Controller annotations with @openapi blocks, including required:

x-visibility (public | partner | internal)

x-owner (owning team/service)

x-sla (support/service level)

openapi.json build script (npm run openapi:build)

Visibility gate script that fails the build if any required extension is missing

Swagger UI served at /api/docs and raw spec at /api/openapi

Starter example with journeys.controller.ts

Why
Enforces full endpoint documentation coverage before merge

Keeps docs in sync with code (no manual drift)

Makes it easy for internal/external partners to explore the API

Improves onboarding speed for developers

Next steps
Annotate all remaining controllers using the same @openapi + Zod schema pattern

Import each controller’s schema register function into scripts/build-openapi.ts

Enable CI checks to block merges when coverage is incomplete